### PR TITLE
fix(ci): убрать неподдерживаемый php из матрицы CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,6 @@ jobs:
       matrix:
         language:
           - 'python'
-          - 'php'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Root cause

CodeQL has **no PHP analyzer**. Its supported languages are: `c/cpp`, `c#`, `go`, `java/kotlin`, `javascript/typescript`, `python`, `ruby`, `swift`.

The CodeQL workflow [.github/workflows/codeql.yml](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/.github/workflows/codeql.yml) listed `php` in its language matrix, so the **Analyze (php)** job failed in ~12s on **every** push and pull request with:

```
Did not recognize the following languages: php
```

## Fix

The matrix already contained `python`, and the repo has real first-party Python source (e.g. [v02/generate.py](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v02/generate.py), [v02/install.py](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v00/install.py), and ~18 tracked `.py` scripts under `v00/`/`v02/`). So this PR simply **removes the `php` matrix entry and keeps `python`** — the `Analyze (python)` job continues to run against a valid, non-empty matrix.

One-file diff; the `category` line is unchanged. Mirrors the earlier MWS fix (case: another supported language already present, so just drop `php`).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>