### PR TITLE
fix(security): prepared statements in dal.php + JSONP callback whitelist (closes #27)

### DIFF
--- a/v02/makotemplates/web/webtc/dal.php
+++ b/v02/makotemplates/web/webtc/dal.php
@@ -27,6 +27,12 @@ class Dal {
  public $status;
  public function __construct($dict,$dbname=null) {
   $this->dict=strtolower($dict);
+  // The dict is used as a SQL table identifier, which cannot be supplied as a
+  // bound parameter. Restrict it to a safe charset so a hostile 'dict' value
+  // cannot be injected into the table name. Anything else => no usable db.
+  if (!preg_match('/^[a-z0-9_]+$/',$this->dict)) {
+   $this->dict = '';
+  }
   $this->dbname = $dbname;
   $this->dictinfo = new DictInfo($dict);
   $sqlitedir = $this->dictinfo->sqlitedir;
@@ -112,45 +118,53 @@ class Dal {
    $this->file_db_xml = null;  
   }
  }
- public function get($sql) {
+ public function get($sql,$params=array()) {
   $ansarr = array();
   if (!$this->file_db) {
    //"file_db is null for $this->sqlitefile.
    return $ansarr;
   }
-  $result = $this->file_db->query($sql);
-  if ($result == false) {
+  // Always go through a prepared statement so callers can bind values safely.
+  try {
+   $stmt = $this->file_db->prepare($sql);
+   $stmt->execute($params);
+  } catch (PDOException $e) {
    return $ansarr;
   }
-  foreach($result as $m) {
+  foreach($stmt as $m) {
    $rec = array($m['key'],$m['lnum'],$m['data']);
    $ansarr[]=$rec;
   }
-  return $ansarr; 
+  return $ansarr;
  }
- public function get_xml($sql) {
+ public function get_xml($sql,$params=array()) {
   $ansarr = array();
   if (!$this->file_db_xml) {
    dbgprint($this->dbg, "file_db_xml is null. sqlitefile={$this->sqlitefile}\n");
    return $ansarr;
   }
-  $result = $this->file_db_xml->query($sql);
-  foreach($result as $m) {
+  try {
+   $stmt = $this->file_db_xml->prepare($sql);
+   $stmt->execute($params);
+  } catch (PDOException $e) {
+   return $ansarr;
+  }
+  foreach($stmt as $m) {
    $rec = array($m['key'],$m['lnum'],$m['data']);
    $ansarr[]=$rec;
   }
-  return $ansarr; 
+  return $ansarr;
  }
  public function get1($key) {
   // Returns associative array for the records in dictionary with this key
-  $sql = "select * from {$this->dict} where key='$key' order by lnum";
-  return $this->get($sql);
+  $sql = "select * from {$this->dict} where key=:key order by lnum";
+  return $this->get($sql,array(':key'=>$key));
  }
  public function get1_xml($key) {
   // Returns associative array for the records in dictionary with this key
-  $sql = "select * from {$this->dict} where key='$key' order by lnum";
+  $sql = "select * from {$this->dict} where key=:key order by lnum";
   dbgprint($this->dbg, "get1_xml, sql=$sql\n");
-  return $this->get_xml($sql);
+  return $this->get_xml($sql,array(':key'=>$key));
  }
 
  public function get2($L1,$L2) {
@@ -158,13 +172,15 @@ class Dal {
   // returns an array of records, one for each L-value in the range
   // $L1 <= $L <= $L2
   // each record is an array with three elements: key,lnum,data
-  $sql="select * from {$this->dict} where  $L1 <= lnum and lnum <= $L2  order by lnum"; 
+  // $L1,$L2 are numeric lnum bounds; cast to float so they cannot inject SQL.
+  $L1 = (float)$L1; $L2 = (float)$L2;
+  $sql="select * from {$this->dict} where  $L1 <= lnum and lnum <= $L2  order by lnum";
   return $this->get($sql);
  }
  public function get3($key) {
   // returns an array of records, which start like $key
-  $sql = "select * from {$this->dict} where key LIKE '$key%' order by lnum";
-  return $this->get($sql);
+  $sql = "select * from {$this->dict} where key LIKE :pat order by lnum";
+  return $this->get($sql,array(':pat'=>$key . '%'));
  }
 
  public function get3a_keydoc($key,$max) {
@@ -175,12 +191,15 @@ class Dal {
   if ($db == null) {return array();}
   $pragma="PRAGMA case_sensitive_like=true;";
   $db->query($pragma);
-  $sql = " select * from {$this->keydoc_tabname} where {$this->keydoc_tabid} LIKE '$key%' LIMIT $max";
+  $max = (int)$max; // LIMIT cannot be a bound parameter; force integer
+  $sql = " select * from {$this->keydoc_tabname} where {$this->keydoc_tabid} LIKE :pat LIMIT $max";
   dbgprint($dbg,"get3a_keydoc: sql=$sql\n");
- $result = $db->query($sql);
- dbgprint($dbg,"get3a_keydoc $key->" . count($result) . "\n");
+ $stmt = $db->prepare($sql);
+ $stmt->execute(array(':pat'=>$key . '%'));
+ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+ dbgprint($dbg,"get3a_keydoc $key->" . count($rows) . "\n");
  $keys = array();
- foreach($result as $m) {
+ foreach($rows as $m) {
   // expect th
   // $m[1] is a string.  A comma-separated list of keys
   $newkeys = explode(",",$m['data']);
@@ -193,8 +212,8 @@ class Dal {
  $arr = array();
  foreach($keys as $key1) {
 
-  $sql = " select * from {$this->dict} where key='$key1' order by lnum;" ;
-  $ans1 = $this->get($sql);
+  $sql = " select * from {$this->dict} where key=:key order by lnum;" ;
+  $ans1 = $this->get($sql,array(':key'=>$key1));
   dbgprint($dbg,"get3a_keydoc($key1) ans1 has " . count($ans1) . "results\n");
   if (count($ans1) > 0) {
    $rec = $ans1[0];
@@ -232,16 +251,18 @@ class Dal {
   $db = $this->file_db;
   $pragma="PRAGMA case_sensitive_like=true;";
   $db->query($pragma);
-  $sql = " select * from {$this->dict} where key LIKE '$key%' order by lnum LIMIT $max";
-  return $this->get($sql);
+  $max = (int)$max; // LIMIT cannot be a bound parameter; force integer
+  $sql = " select * from {$this->dict} where key LIKE :pat order by lnum LIMIT $max";
+  return $this->get($sql,array(':pat'=>$key . '%'));
  }
  public function prev_get3a($key,$max) {
   // returns an array of records, which start like $key
   // Setting a pragma must for case_sensitive
   $pragma="PRAGMA case_sensitive_like=true;";
   $this->file_db->query($pragma);
-  $sql = " select * from {$this->dict} where key LIKE '$key%' order by lnum LIMIT $max";
-  return $this->get($sql);
+  $max = (int)$max; // LIMIT cannot be a bound parameter; force integer
+  $sql = " select * from {$this->dict} where key LIKE :pat order by lnum LIMIT $max";
+  return $this->get($sql,array(':pat'=>$key . '%'));
  }
 
  public function get3b($key,$max) {
@@ -255,8 +276,10 @@ class Dal {
 */
   $pragma="PRAGMA case_sensitive_like=true;";
   $this->file_db->query($pragma);
-  $sql = " select * from {$this->dict} where key LIKE '$key' order by lnum LIMIT $max";
-  return $this->get($sql);
+  $max = (int)$max; // LIMIT cannot be a bound parameter; force integer
+  // $key may already contain % / _ wildcards supplied by the caller.
+  $sql = " select * from {$this->dict} where key LIKE :pat order by lnum LIMIT $max";
+  return $this->get($sql,array(':pat'=>$key));
  }
 
 public function get4a($lnum0,$max) {
@@ -264,7 +287,8 @@ public function get4a($lnum0,$max) {
   // in mw, with L=99930.1, $lnum0 appears as if L=99930.1000000001
   // To guard against this, we round lnum0 to 3 decimal places.
   //  [This is consistent with the schema definition]
-  $lnum0 = round($lnum0,3);
+  $lnum0 = round($lnum0,3); // numeric, cannot inject
+  $max = (int)$max; // LIMIT cannot be a bound parameter; force integer
   $sql = "select * from {$this->dict} where (lnum < '$lnum0') order by lnum DESC LIMIT $max";
   return $this->get($sql);
  }
@@ -273,7 +297,8 @@ public function get4a($lnum0,$max) {
   // in mw, with L=99930.1, $lnum0 appears as if L=99930.1000000001
   // To guard against this, we round lnum0 to 3 decimal places.
   //  [This is consistent with the schema definition]
-  $lnum0 = round($lnum0,3);
+  $lnum0 = round($lnum0,3); // numeric, cannot inject
+  $max = (int)$max; // LIMIT cannot be a bound parameter; force integer
   $sql = "select * from {$this->dict} where ('$lnum0' < lnum) order by lnum LIMIT $max";
   return $this->get($sql);
  }
@@ -285,8 +310,10 @@ public function get1_keydoc_keys($key) {
  $dbg=False;
   $pragma="PRAGMA case_sensitive_like=true;";
   $this->keydoc_db->query($pragma);
-  $sql = " select data from {$this->keydoc_tabname} where {$this->keydoc_tabid}='$key';";
- $result = $this->keydoc_db->query($sql);
+  $sql = " select data from {$this->keydoc_tabname} where {$this->keydoc_tabid}=:key;";
+ $stmt = $this->keydoc_db->prepare($sql);
+ $stmt->execute(array(':key'=>$key));
+ $result = $stmt->fetchAll(PDO::FETCH_NUM);
  // $result is an array; expect it to be of length = 0 or 1
  $keys = array();
  foreach($result as $m) {
@@ -557,11 +584,13 @@ public function getgeneral($key,$table) {
    return array();
   }
 #$sql = "select * from $table where id='$key'";
-$key = str_replace("'","''",$key); // 02-08-2020
-$sql = "select * from $table where {$this->tabid}='$key'";
-$result = $this->file_db->query($sql);
+// $table is a SQL identifier (cannot be bound); restrict to a safe charset.
+if (!preg_match('/^[A-Za-z0-9_]+$/',$table)) { return array(); }
+$sql = "select * from $table where {$this->tabid}=:key";
+$stmt = $this->file_db->prepare($sql);
+$stmt->execute(array(':key'=>$key));
 $ansarr = array();
-foreach($result as $m) {
+foreach($stmt as $m) {
  $ansarr[] = $m;
 }
 return $ansarr;

--- a/v02/makotemplates/web/webtc/getword.php
+++ b/v02/makotemplates/web/webtc/getword.php
@@ -13,8 +13,17 @@ function getwordCall() {
   $temp = new GetwordClass();
   $table1 = $temp->table1;
   if (isset($_GET['callback'])) {
+   $callback = $_GET['callback'];
+   // Only allow a safe JSONP callback identifier. Echoing the raw callback
+   // is a reflected-XSS / JSONP-injection vector, so reject anything else.
+   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+    header('content-type: text/plain; charset=utf-8');
+    http_response_code(400);
+    echo "invalid callback";
+    return;
+   }
    $json = json_encode($table1);
-   echo "{$_GET['callback']}($json)";
+   echo "{$callback}($json)";
   }else {
    echo $table1;
   }


### PR DESCRIPTION
## Summary

Closes the SQL-injection and reflected-XSS surface in the web-frontend's request path. This addresses the long-open [#27 “key and xss”](https://github.com/sanskrit-lexicon/csl-websanlexicon/issues/27).

### The vulnerability

[`v02/makotemplates/web/webtc/dal.php`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v02/makotemplates/web/webtc/dal.php) built nearly every SQL query by interpolating request-derived values straight into the string (only `getgeneral()` escaped, via `str_replace`). The user-supplied headword reaches it through:

`$_REQUEST['key' | 'word' | 'citation']` → [`parm.php`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v02/makotemplates/web/webtc/parm.php) → [`getword_data.php`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v02/makotemplates/web/webtc/getword_data.php) → `Dal::get1_mwalt()` → `get1()` → `... where key='$key'`.

Separately, [`getword.php`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v02/makotemplates/web/webtc/getword.php) echoed the JSONP `callback` GET parameter verbatim (`echo "{$_GET['callback']}($json)";`) — a reflected-XSS / JSONP-injection vector.

### The fix

**`dal.php`**
- `get()` / `get_xml()` now run through PDO `prepare()` + `execute()` and take a bound-parameter array.
- Every string-key method binds its key: `get1`, `get1_xml`, `get3`, `get3a`, `get3a_keydoc`, `prev_get3a`, `get3b`, `get1_keydoc_keys`, `getgeneral`.
- Numeric inputs (`L1`/`L2`, `lnum0`, `max`/`LIMIT`) are cast to `float`/`int` — `LIMIT` and bare numerics can't be bound parameters.
- `$dict` and `$table` are SQL **identifiers** (not bindable): validated against a safe charset, bail out otherwise.

**`getword.php`**
- `callback` validated against a safe JS-identifier pattern; rejected with HTTP 400 otherwise.

### Scope & propagation

These are the **source-of-truth Mako templates**. Generated per-dictionary copies and the legacy `v00/` tree are out of scope — they pick the fix up on the next server-side regeneration (`redo_*`).

### Verification

- `php -l` clean on both files (PHP 8.2.12).
- Behavior preserved: PDO default fetch mode (`FETCH_BOTH`) keeps the existing associative/numeric row access working; keydoc paths use explicit `FETCH_ASSOC`/`FETCH_NUM` to match prior `$m['data']` / `$m[0]` usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
