### PR TITLE
Stop Semgrep scanning archived webbackup/ (clears ~679 noise alerts)

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,5 @@
+# Archived backups of old per-dictionary PHP web interfaces. These files are
+# not served and not maintained; SAST-scanning them produced ~680 reflected-
+# XSS findings that are pure noise on the Security tab. Live code under v00/
+# and v02/ is still scanned.
+webbackup/


### PR DESCRIPTION
## What

Adds a `.semgrepignore` that excludes the `webbackup/` directory from Semgrep SAST.

## Why

**679 of the repo's 687 open Semgrep alerts** are reflected-XSS patterns (`echo`/`print $_REQUEST`) inside `webbackup/` — an **archived backup** of old per-dictionary PHP web interfaces (`webbackup/<dict>/00/webtc2/query.php`, etc.). That code is not served and not maintained, so the findings are pure noise drowning the Security tab.

Excluding `webbackup/` drops those ~679 alerts (the next scan supersedes them) and leaves the **8 live findings under `v00/` and `v02/` still scanned** — those are being triaged separately.

Config only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)