### PR TITLE
Validate JSONP callback in query.php (reflected-XSS, completes #27)

### DIFF
--- a/v02/makotemplates/web/webtc2/query.php
+++ b/v02/makotemplates/web/webtc2/query.php
@@ -33,7 +33,17 @@ $lastLnum = $model->lastLnum;
 $ans = construct_outputarr($getParms,$model,$dictcode,$getParms->filter);
 $json = json_encode($ans);
 if(isset($_GET['callback'])) {
- echo "{$_GET['callback']}($json)";
+ $callback = $_GET['callback'];
+ // $callback is reflected into the JSONP response; an unrestricted value is a
+ // reflected-XSS / JSONP-injection vector, so reject anything that is not a
+ // plain JS identifier (mirrors the guard already in webtc/getword.php, #27).
+ if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+  header('content-type: text/plain; charset=utf-8');
+  http_response_code(400);
+  echo "invalid callback";
+  exit;
+ }
+ echo "{$callback}($json)";
 }else {
  echo $json;
 }


### PR DESCRIPTION
## What

Validates the JSONP `callback` parameter in `v02/makotemplates/web/webtc2/query.php` before reflecting it, using the same guard already present in [`webtc/getword.php`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v02/makotemplates/web/webtc/getword.php).

```diff
 if(isset($_GET['callback'])) {
+ $callback = $_GET['callback'];
+ if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+  header('content-type: text/plain; charset=utf-8');
+  http_response_code(400); echo "invalid callback"; exit;
+ }
-  echo "{$_GET['callback']}($json)";
+  echo "{$callback}($json)";
 }else {
   echo $json;
 }
```

## Why

`query.php` reflected `$_GET['callback']` straight into the response body with no validation — a reflected-XSS / JSONP-injection vector (Semgrep `php.lang.security.injection.echoed-request`). [PR #63](https://github.com/sanskrit-lexicon/csl-websanlexicon/pull/63) (issue #27) added exactly this guard to `getword.php` but missed `query.php`; this completes that fix. The guard rejects any callback that isn't a plain JS identifier.

Note: `query_gather.php` carries the same pattern but is dead code ("Not used as of August 2020. Replaced by query_gather1.php"); the generated per-dictionary copies (GRA, etc.) pick this up on the next server-side regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)