### PR TITLE
Harden grav00 servepdf $page; mark dead query_gather.php won't-fix (#27)

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -3,3 +3,11 @@
 # XSS findings that are pure noise on the Security tab. Live code under v00/
 # and v02/ is still scanned.
 webbackup/
+
+# query_gather.php is dead across every version: "Not used as of August 2020.
+# Replaced by query_gather1.php" (see the makotemplates header comment). It is
+# never served, so its reflected-XSS findings are won't-fix noise. The live
+# replacement, query_gather1.php, is NOT ignored and is still scanned.
+v00/grav00/webtc2/query_gather.php
+v00/makotemplates/webtc2/query_gather.php
+v02/makotemplates/web/webtc2/query_gather.php

--- a/v00/grav00/webtc/servepdf.php
+++ b/v00/grav00/webtc/servepdf.php
@@ -7,6 +7,14 @@ error_reporting( error_reporting() & ~E_NOTICE );
 
 $page = $_GET['page'] ;
 if (!$page) {$page = $argv[1];}
+// Defensive hardening (issue #27): $page is used ONLY as a pdffiles.txt lookup
+// key and via intval() inside getfiles(); the echoed values ($filename,
+// $pageprev, $pagenext) come from pdffiles.txt, never from $page, so the raw
+// value is not reflected (the Semgrep finding here is a taint false positive).
+// We still constrain $page to the characters legitimate page identifiers use
+// (digits and the vol-page separators '-' / ','); anything else is cleared and
+// simply falls through to getfiles()'s existing "default to first page" path.
+if (!preg_match('/^[0-9,\-]*$/', (string)$page)) { $page = ''; }
 list($filename,$pageprev,$pagenext)=getfiles($page);
 
 $HEADER='<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"


### PR DESCRIPTION
## Summary

Second-pass cleanup of the remaining **v00** PHP reflected-XSS Semgrep findings, after the JSONP callback fixes ([#27](https://github.com/sanskrit-lexicon/csl-websanlexicon/issues/27), PR [#63](https://github.com/sanskrit-lexicon/csl-websanlexicon/pull/63) / [#67](https://github.com/sanskrit-lexicon/csl-websanlexicon/pull/67)) already landed in the v02 templates. Both items here are **non-exploitable**; this PR makes that explicit and clears the Security-tab noise.

## 1. `servepdf.php` — taint false positive, hardened anyway

[`v00/grav00/webtc/servepdf.php`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/security/servepdf-harden-querygather-wontfix/v00/grav00/webtc/servepdf.php) takes `$_GET['page']` and passes it to `getfiles()`. Tracing the data flow: `$page` is used **only** as a `pdffiles.txt` lookup key and via `intval()`. The values that actually reach output (`$filename`, `$pageprev`, `$pagenext`) all come from `pdffiles.txt` — the raw `$page` is **never echoed**. So the Semgrep reflected-XSS finding is a taint **false positive** (it doesn't see that the value is replaced by a file-keyed lookup).

Hardened defensively anyway — constrain `$page` to the characters legitimate page identifiers use (`[0-9,-]`); anything else clears to `''` and falls through to the existing "default to first page" branch (behavior-preserving):

```php
if (!preg_match('/^[0-9,\-]*$/', (string)$page)) { $page = ''; }
```

> Note: this `grav00` copy is a **stale pre-2019 generated instance** (the canonical template was refactored to `ServepdfClass` in 2019 — [`v00/makotemplates/webtc/servepdfClass.php`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v00/makotemplates/webtc/servepdfClass.php) — which normalizes `$page` and is the same FP class). Hardening the checked-in stale copy clears the named finding without touching the broadly-regenerated template.

## 2. `query_gather.php` — dead code, won't-fix

`query_gather.php` is dead across every version: *"Not used as of August 2020. Replaced by query_gather1.php"* (header comment in [`v02/makotemplates/web/webtc2/query_gather.php`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v02/makotemplates/web/webtc2/query_gather.php)). It is never served, so any SAST finding on it is won't-fix noise. Added the three live-scanned copies to [`.semgrepignore`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/security/servepdf-harden-querygather-wontfix/.semgrepignore) (same rationale as the existing `webbackup/` stanza). The **live** replacement, `query_gather1.php`, stays scanned.

## Context: items already complete upstream

- The JSONP callback reflected-XSS guard (`/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/`) is already on `master` for both `v02/makotemplates/web/webtc/getword.php` and `webtc2/query.php` (PR #63 / #67, issue #27). The `v00/grav00` getword/query copies do **not** wrap the callback (they only set the JSON header) — not vulnerable.
- The matching `gra-dev` display copies in the GRA repo are fixed in [GRA#45](https://github.com/sanskrit-lexicon/GRA/pull/45); the `list02php` reflected-XSS in MWS is fixed in [MWS#211](https://github.com/sanskrit-lexicon/MWS/pull/211).

## Verification

- `php -l` clean on `v00/grav00/webtc/servepdf.php` (PHP 8.2).
- `$page` guard: `0001`, `123`, `1-001`, `1,2`, `''` pass unchanged; `1"><script>`, `../../etc`, `<svg/onload=1>` are cleared to the default-page path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)