### PR TITLE
ci: bump codeql-action to v4 (build-mode none)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,17 +28,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+          # python is interpreted: no compilation, so skip autobuild
+          build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Bumps the CodeQL workflow to the current action major versions:
`codeql-action` v3 -> **v4**, `actions/checkout` v4 -> **v5**, and replaces the `autobuild` step with `build-mode: none` (python is interpreted, no compilation).

## Why

Matches the pattern already adopted by the upstream-fixed dict repos (AP/AP90/GRA/MWS/PWK) and clears the Node-20 deprecation on the older action versions. Pre-empts the equivalent Dependabot bump. No behavior change to the analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)