### PR TITLE
chore: restore .ai_state.md to tracking (session-journal protocol)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,0 +1,48 @@
+# Project Objective: Harden and modernise the CDSL web-frontend
+
+Security, CI, and repo-hygiene improvements to csl-websanlexicon (the
+Python + Mako generator that renders per-dictionary PHP + SQLite web apps).
+Display/content correctness issues are tracked as GitHub issues; dictionary
+*content* fixes belong in csl-orig, not here.
+
+## ➡️ Next Steps (Queue)
+
+- [ ] Merge PR #62 (drop unsupported `php` from the CodeQL matrix) — it makes the
+      `Analyze (php)` check red on every PR.
+- [ ] Propagate the PR #63 security fix (prepared statements in `dal.php`) to
+      `csl-apidev`, since `dal.php`/`basicadjust.php`/`basicdisplay.php` are shared
+      and copied there via `v02/apidev_copy.sh` (see `v02/apidev_readme.md`).
+- [ ] Issue #47 — "display breaks": parenthetical `(KaM)` wraps wrongly across a
+      line break in AP90 and others. Real frontend bug in `basicdisplay.php` div /
+      line-break handling; needs runtime verification (XAMPP).
+- [ ] Issue #46 — `anarman` (MW) shows twice in the hierarchy list (dedup logic).
+- [ ] Issue #33 — revise `<div>` indentation coding (partly done per the issue).
+
+## 🚧 Current Work-In-Progress (WIP)
+
+- [ ] (no active task)
+
+## 🧠 Dev Notes & Hypotheses
+
+- 2026-06-13: `v02/makotemplates/web/` is a **Mako template tree**. Only
+  inventory-category `T` files contain Mako syntax (`${…}`, `<% %>`); the rest
+  are copied verbatim. A raw `php -l` over the tree fails on the `T` files — CI
+  lints the verbatim files and Mako-compiles the rest. Local PHP: `C:\xampp\php`.
+- 2026-06-13: `dbg_apidev.txt` is the **runtime debug log** written by
+  `webtc/dbgprint.php`. It had been committed accidentally; the `acala` parse
+  errors in it are **stale** (that log says `acala` = L 500, but in the current
+  AP90 source L 500 is `atapas` and `acala` is L 321 with clean markup — no live
+  data bug). Removed from the repo and added to `.gitignore`; `basicdisplay.php`
+  no longer force-logs (`dbgprint(true,…)` → `dbgprint($this->dbg,…)`).
+
+## ✅ Completed (Recent only)
+
+- PR #63 — security: prepared statements throughout `dal.php`, identifier
+  whitelisting, JSONP callback validation in `getword.php` (closes #27).
+- PR #64 — CI: replaced the no-op Laravel `ci.yml` with real PHP/Python/Mako
+  lint; added `semgrep.yml` for PHP SAST (CodeQL can't analyse PHP). **Merged.**
+- This branch — hygiene/docs: removed committed `dbg_apidev.txt` (+ gitignore),
+  graceful parse-error fallback in `basicdisplay.php`, real architecture/usage
+  `readme.md`, and this populated `.ai_state.md`.
+
+- 2026-06-17: restored .ai_state.md to tracking (org session-journal protocol; PR #70 had untracked it).

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,3 @@ scratch/*
 
 # runtime debug log written by webtc/dbgprint.php — never commit it
 dbg_apidev.txt
-
-# session journal — local only, never commit
-.ai_state.md


### PR DESCRIPTION
PR #70 (the repo-hygiene PR) inadvertently untracked `.ai_state.md`. The org session-journal protocol (CLAUDE.md) requires `.ai_state.md` to stay **tracked**, so this restores it.

### What this does
- Recovers the last tracked `.ai_state.md` from history (the version deleted in #70) and re-adds it.
- Removes `.ai_state.md` from `.gitignore`.
- Logs the restore under `## Completed`.

No BOM; no functional code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)